### PR TITLE
NodeEditor: inherit FocusScope; embedder owns keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,12 +314,6 @@ callback link-hovered();
 /// Viewport changed (pan/zoom)
 callback viewport-changed();
 
-/// User pressed Delete key
-callback delete-selected();
-
-/// User pressed Ctrl+N or clicked add button
-callback add-node-requested();
-
 /// User right-clicked (context menu)
 callback context-menu-requested();
 

--- a/examples/advanced/ui/ui.slint
+++ b/examples/advanced/ui/ui.slint
@@ -202,7 +202,7 @@ export component MainWindow inherits Window {
     callback update-viewport(float, float, float);  // zoom, pan-x, pan-y (for link position updates)
     callback create-link <=> editor.link-requested;
     callback delete-selected-nodes();  // delete all selected nodes
-    callback add-node <=> editor.add-node-requested;
+    callback add-node();
 
     // Filter node callbacks
     callback filter-type-changed(int, int);  // node-id, new-index
@@ -296,154 +296,176 @@ export component MainWindow inherits Window {
         editor.graph-max-y = graph-max-y * 1px;
     }
 
-    // The pure Slint NodeEditor handles all three layers:
-    // 1. Background with grid
-    // 2. Children (nodes and links) - placed via @children
-    // 3. Overlay for selection box and link preview
-    editor := NodeEditor {
+    // Focus the editor on startup so keyboard shortcuts work without first
+    // clicking the editor. NodeEditor inherits FocusScope but defines no
+    // key-pressed handler — embedders own the keymap (see `shortcuts` below).
+    init => {
+        editor.focus();
+    }
+
+    // App-level keymap. NodeEditor exposes operations (delete-selected,
+    // cancel-link-creation, …) and state (is-creating-link, …) but does not
+    // bind any keys itself. Wrap it in a parent FocusScope and bind here:
+    // rejected keys from the focused descendant bubble up to this handler.
+    shortcuts := FocusScope {
         width: 100%;
         height: 100%;
-        pan-x <=> root.pan-x;
-        pan-y <=> root.pan-y;
-        zoom <=> root.zoom;
-        min-zoom: 0.25;
-        max-zoom: 4.0;
-        background-color: #1a1a1a;
-        grid-spacing: 24px;
-        grid-snapping <=> grid-snap-enabled;
-        grid-color: #333333;
-        grid-commands <=> root.grid-commands;
-        links <=> root.links;
 
-        // Set pin hit radius from globals
-        pin-hit-radius: NodeConstants.pin-size * zoom * 0.66;
-        link-hover-distance: 8px;
-
-        // Callbacks aliased to root
-
-
-        // Event callbacks aliased to root:
-        // link-requested => root.create-link
-        // node-drag-ended => root.commit-drag
-        // add-node-requested => root.add-node
-
-        context-menu-requested => {
-            debug("Context menu at: " + editor.context-menu-x / 1px + ", " + editor.context-menu-y / 1px);
+        key-pressed(event) => {
+            if (event.text == Key.Delete || event.text == Key.Backspace) {
+                root.delete-selected-nodes();
+                root.delete-selected-links();
+                return accept;
+            }
+            if (event.modifiers.control && (event.text == "n" || event.text == "N")) {
+                root.add-node();
+                return accept;
+            }
+            if (event.text == Key.Escape && editor.is-creating-link) {
+                editor.cancel-link-creation();
+                return accept;
+            }
+            return reject;
         }
 
+        // The pure Slint NodeEditor handles all three layers:
+        // 1. Background with grid
+        // 2. Children (nodes and links) - placed via @children
+        // 3. Overlay for selection box and link preview
+        editor := NodeEditor {
+            width: 100%;
+            height: 100%;
+            pan-x <=> root.pan-x;
+            pan-y <=> root.pan-y;
+            zoom <=> root.zoom;
+            min-zoom: 0.25;
+            max-zoom: 4.0;
+            background-color: #1a1a1a;
+            grid-spacing: 24px;
+            grid-snapping <=> grid-snap-enabled;
+            grid-color: #333333;
+            grid-commands <=> root.grid-commands;
+            links <=> root.links;
 
+            // Set pin hit radius from globals
+            pin-hit-radius: NodeConstants.pin-size * zoom * 0.66;
+            link-hover-distance: 8px;
 
-        // Forward selection checking callbacks to root (version param ignored, just for cache invalidation)
-        is-selected(node-id, version) => {
-            return root.is-node-selected(node-id);
-        }
-        is-link-selected(link-id, version) => {
-            return root.is-link-selected(link-id);
-        }
+            // Event callbacks aliased to root:
+            // link-requested => root.create-link
+            // node-drag-ended => root.commit-drag
 
-        viewport-changed => {
-            root.update-viewport(zoom, pan-x / 1px, pan-y / 1px);
-        }
+            context-menu-requested => {
+                debug("Context menu at: " + editor.context-menu-x / 1px + ", " + editor.context-menu-y / 1px);
+            }
 
-        delete-selected => {
-            root.delete-selected-nodes();
-            root.delete-selected-links();
-        }
+            // Forward selection checking callbacks to root (version param ignored, just for cache invalidation)
+            is-selected(node-id, version) => {
+                return root.is-node-selected(node-id);
+            }
+            is-link-selected(link-id, version) => {
+                return root.is-link-selected(link-id);
+            }
 
-        // Nodes - children of NodeEditor
-        for node-data in nodes: Node {
-            title: node-data.title;
-            node-id: node-data.id;
-            selected: editor.is-selected(node-data.id, editor.selection-version);
-            world-x: node-data.world-x * 1px;
-            world-y: node-data.world-y * 1px;
-            drag-offset-x: editor.is-selected(node-data.id, editor.selection-version) ? editor.drag-offset-x : 0px;
-            drag-offset-y: editor.is-selected(node-data.id, editor.selection-version) ? editor.drag-offset-y : 0px;
-            zoom: zoom;
-            pan-x: pan-x;
-            pan-y: pan-y;
-            clicked(id, shift) => {
-                editor.handle-node-click(id, shift);
+            viewport-changed => {
+                root.update-viewport(zoom, pan-x / 1px, pan-y / 1px);
             }
-            drag-started(id, already-selected, wx, wy) => {
-                editor.start-node-drag(id, already-selected, wx, wy);
-            }
-            drag-moved(id, offset-x, offset-y) => {
-                editor.update-node-drag(offset-x, offset-y);
-            }
-            drag-ended(id, delta-x, delta-y) => {
-                editor.end-node-drag(delta-x, delta-y);
-            }
-            pin-position-changed(pin-id, node-id, pin-type, x, y) => {
-                editor.report-pin-position(pin-id, node-id, pin-type, x, y);
-            }
-            pin-drag-started(pin-id, x, y) => {
-                editor.start-link-from-pin(pin-id, x, y);
-            }
-            pin-drag-moved(pin-id, x, y) => {
-                editor.update-link-end(x, y);
-            }
-            pin-drag-ended(pin-id, x, y) => {
-                editor.update-link-end(x, y);
-                editor.complete-link-creation();
-            }
-            report-rect(id, x, y, w, h) => {
-                editor.report-node-rect(id, x, y, w, h);
-            }
-        }
 
-        // Filter nodes - complex nodes with widgets
-        for filter-data in filter-nodes: FilterNode {
-            title: filter-data.title;
-            node-id: filter-data.id;
-            selected: editor.is-selected(filter-data.id, editor.selection-version);
-            world-x: filter-data.world-x * 1px;
-            world-y: filter-data.world-y * 1px;
-            drag-offset-x: editor.is-selected(filter-data.id, editor.selection-version) ? editor.drag-offset-x : 0px;
-            drag-offset-y: editor.is-selected(filter-data.id, editor.selection-version) ? editor.drag-offset-y : 0px;
-            zoom: zoom;
-            pan-x: pan-x;
-            pan-y: pan-y;
-            filter-type-index: filter-data.filter-type-index;
-            enabled: filter-data.enabled;
-            processed-count: filter-data.processed-count;
+            // Nodes - children of NodeEditor
+            for node-data in nodes: Node {
+                title: node-data.title;
+                node-id: node-data.id;
+                selected: editor.is-selected(node-data.id, editor.selection-version);
+                world-x: node-data.world-x * 1px;
+                world-y: node-data.world-y * 1px;
+                drag-offset-x: editor.is-selected(node-data.id, editor.selection-version) ? editor.drag-offset-x : 0px;
+                drag-offset-y: editor.is-selected(node-data.id, editor.selection-version) ? editor.drag-offset-y : 0px;
+                zoom: zoom;
+                pan-x: pan-x;
+                pan-y: pan-y;
+                clicked(id, shift) => {
+                    editor.handle-node-click(id, shift);
+                }
+                drag-started(id, already-selected, wx, wy) => {
+                    editor.start-node-drag(id, already-selected, wx, wy);
+                }
+                drag-moved(id, offset-x, offset-y) => {
+                    editor.update-node-drag(offset-x, offset-y);
+                }
+                drag-ended(id, delta-x, delta-y) => {
+                    editor.end-node-drag(delta-x, delta-y);
+                }
+                pin-position-changed(pin-id, node-id, pin-type, x, y) => {
+                    editor.report-pin-position(pin-id, node-id, pin-type, x, y);
+                }
+                pin-drag-started(pin-id, x, y) => {
+                    editor.start-link-from-pin(pin-id, x, y);
+                }
+                pin-drag-moved(pin-id, x, y) => {
+                    editor.update-link-end(x, y);
+                }
+                pin-drag-ended(pin-id, x, y) => {
+                    editor.update-link-end(x, y);
+                    editor.complete-link-creation();
+                }
+                report-rect(id, x, y, w, h) => {
+                    editor.report-node-rect(id, x, y, w, h);
+                }
+            }
 
-            clicked(id, shift) => {
-                editor.handle-node-click(id, shift);
-            }
-            drag-started(id, already-selected, wx, wy) => {
-                editor.start-node-drag(id, already-selected, wx, wy);
-            }
-            drag-moved(id, offset-x, offset-y) => {
-                editor.update-node-drag(offset-x, offset-y);
-            }
-            drag-ended(id, delta-x, delta-y) => {
-                editor.end-node-drag(delta-x, delta-y);
-            }
-            pin-position-changed(pin-id, node-id, pin-type, x, y) => {
-                editor.report-pin-position(pin-id, node-id, pin-type, x, y);
-            }
-            pin-drag-started(pin-id, x, y) => {
-                editor.start-link-from-pin(pin-id, x, y);
-            }
-            pin-drag-moved(pin-id, x, y) => {
-                editor.update-link-end(x, y);
-            }
-            pin-drag-ended(pin-id, x, y) => {
-                editor.update-link-end(x, y);
-                editor.complete-link-creation();
-            }
-            report-rect(id, x, y, w, h) => {
-                editor.report-node-rect(id, x, y, w, h);
-            }
-            filter-type-changed(id, idx) => {
-                root.filter-type-changed(id, idx);
-            }
-            toggle-enabled(id) => {
-                root.filter-toggle-enabled(id);
-            }
-            reset-clicked(id) => {
-                root.filter-reset(id);
+            // Filter nodes - complex nodes with widgets
+            for filter-data in filter-nodes: FilterNode {
+                title: filter-data.title;
+                node-id: filter-data.id;
+                selected: editor.is-selected(filter-data.id, editor.selection-version);
+                world-x: filter-data.world-x * 1px;
+                world-y: filter-data.world-y * 1px;
+                drag-offset-x: editor.is-selected(filter-data.id, editor.selection-version) ? editor.drag-offset-x : 0px;
+                drag-offset-y: editor.is-selected(filter-data.id, editor.selection-version) ? editor.drag-offset-y : 0px;
+                zoom: zoom;
+                pan-x: pan-x;
+                pan-y: pan-y;
+                filter-type-index: filter-data.filter-type-index;
+                enabled: filter-data.enabled;
+                processed-count: filter-data.processed-count;
+
+                clicked(id, shift) => {
+                    editor.handle-node-click(id, shift);
+                }
+                drag-started(id, already-selected, wx, wy) => {
+                    editor.start-node-drag(id, already-selected, wx, wy);
+                }
+                drag-moved(id, offset-x, offset-y) => {
+                    editor.update-node-drag(offset-x, offset-y);
+                }
+                drag-ended(id, delta-x, delta-y) => {
+                    editor.end-node-drag(delta-x, delta-y);
+                }
+                pin-position-changed(pin-id, node-id, pin-type, x, y) => {
+                    editor.report-pin-position(pin-id, node-id, pin-type, x, y);
+                }
+                pin-drag-started(pin-id, x, y) => {
+                    editor.start-link-from-pin(pin-id, x, y);
+                }
+                pin-drag-moved(pin-id, x, y) => {
+                    editor.update-link-end(x, y);
+                }
+                pin-drag-ended(pin-id, x, y) => {
+                    editor.update-link-end(x, y);
+                    editor.complete-link-creation();
+                }
+                report-rect(id, x, y, w, h) => {
+                    editor.report-node-rect(id, x, y, w, h);
+                }
+                filter-type-changed(id, idx) => {
+                    root.filter-type-changed(id, idx);
+                }
+                toggle-enabled(id) => {
+                    root.filter-toggle-enabled(id);
+                }
+                reset-clicked(id) => {
+                    root.filter-reset(id);
+                }
             }
         }
     }

--- a/node-editor.slint
+++ b/node-editor.slint
@@ -53,7 +53,13 @@ export enum BoxSelectionModifier {
 /// - Layer 3: Selection box and link preview overlays
 ///
 /// Computation-heavy operations are delegated to the application via callbacks.
-export component NodeEditor {
+// NodeEditor inherits FocusScope so it IS the keyboard focus surface for the
+// whole editor. Consequences:
+//   * Embedders can call `node-editor.focus()` directly.
+//   * Keys rejected by a focused descendant (e.g. a TextInput inside a node)
+//     bubble up into this component's `key-pressed` handler, so Delete /
+//     Escape / Ctrl+N work even while an in-node input is focused.
+export component NodeEditor inherits FocusScope {
     // === Shared viewport state ===
     in-out property <length> pan-x: 0px;
     in-out property <length> pan-y: 0px;
@@ -216,16 +222,19 @@ export component NodeEditor {
     pure callback compute-link-path(/* start-pin-id */ int, /* end-pin-id */ int, /* version */ int, /* zoom */ float, /* pan-x */ float, /* pan-y */ float) -> string;
 
     // === Callbacks TO Application (events) ===
+    // Keyboard shortcuts are the embedder's responsibility. NodeEditor inherits
+    // FocusScope (so it can be focused via `focus()` and `focus-on-click`), but
+    // defines no `key-pressed` handler — keys land on the focused descendant,
+    // bubble up unhandled, and reach the embedder's parent FocusScope. Bind
+    // operations like `cancel-link-creation()` from there, querying state via
+    // `is-creating-link` as needed.
     callback link-requested(/* start-pin */ int, /* end-pin */ int);
     callback link-cancelled();
     callback link-hovered();
     callback selection-changed();
     callback viewport-changed();
-    callback delete-selected();
-    callback add-node-requested();
     callback context-menu-requested();
     callback node-double-clicked(/* node-id */ int);
-    callback navigate-up();
     callback node-drag-started(/* node-id */ int);
     callback node-drag-ended(/* delta-x */ float, /* delta-y */ float);
 
@@ -637,28 +646,4 @@ export component NodeEditor {
         }
     }
 
-    // === Keyboard handling ===
-    FocusScope {
-        width: 100%;
-        height: 100%;
-
-        key-pressed(event) => {
-            if event.text == Key.Delete || event.text == Key.Backspace {
-                root.delete-selected();
-                accept
-            } else if event.text == Key.Escape {
-                if root.internal-is-creating-link {
-                    root.cancel-link-creation();
-                } else {
-                    root.navigate-up();
-                }
-                accept
-            } else if event.modifiers.control && (event.text == "n" || event.text == "N") {
-                root.add-node-requested();
-                accept
-            } else {
-                reject
-            }
-        }
-    }
 }

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -190,27 +190,11 @@ impl MinimalTestHarness {
             }
         });
 
-        // Delete selected callback
-        window.on_delete_selected({
-            let tracker = tracker.clone();
-            move || {
-                *tracker.delete_selected.borrow_mut() += 1;
-            }
-        });
-
         // Context menu requested callback
         window.on_context_menu_requested({
             let tracker = tracker.clone();
             move || {
                 *tracker.context_menu_requested.borrow_mut() += 1;
-            }
-        });
-
-        // Add node requested callback
-        window.on_add_node_requested({
-            let tracker = tracker.clone();
-            move || {
-                *tracker.add_node_requested.borrow_mut() += 1;
             }
         });
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -22,8 +22,6 @@ pub struct CallbackTracker {
     pub link_cancelled: Rc<RefCell<usize>>,
     /// Count of selection_changed calls
     pub selection_changed: Rc<RefCell<usize>>,
-    /// Count of delete_selected calls
-    pub delete_selected: Rc<RefCell<usize>>,
     /// (node_id, x, y, width, height)
     #[allow(clippy::type_complexity)]
     pub node_rect_changed: Rc<RefCell<Vec<(i32, f32, f32, f32, f32)>>>,
@@ -34,8 +32,6 @@ pub struct CallbackTracker {
     pub update_viewport: Rc<RefCell<Vec<(f32, f32, f32)>>>,
     /// Count of context_menu_requested calls
     pub context_menu_requested: Rc<RefCell<usize>>,
-    /// Count of add_node_requested calls
-    pub add_node_requested: Rc<RefCell<usize>>,
 }
 
 impl CallbackTracker {
@@ -50,11 +46,9 @@ impl CallbackTracker {
         self.link_requested.borrow_mut().clear();
         *self.link_cancelled.borrow_mut() = 0;
         *self.selection_changed.borrow_mut() = 0;
-        *self.delete_selected.borrow_mut() = 0;
         self.node_rect_changed.borrow_mut().clear();
         self.pin_position_changed.borrow_mut().clear();
         self.update_viewport.borrow_mut().clear();
         *self.context_menu_requested.borrow_mut() = 0;
-        *self.add_node_requested.borrow_mut() = 0;
     }
 }

--- a/tests/level1_init.rs
+++ b/tests/level1_init.rs
@@ -109,7 +109,6 @@ fn test_callback_tracker_starts_empty() {
     assert!(harness.tracker.link_requested.borrow().is_empty());
     assert_eq!(*harness.tracker.link_cancelled.borrow(), 0);
     assert_eq!(*harness.tracker.selection_changed.borrow(), 0);
-    assert_eq!(*harness.tracker.delete_selected.borrow(), 0);
 }
 
 #[test]

--- a/tests/level5_keyboard.rs
+++ b/tests/level5_keyboard.rs
@@ -25,33 +25,21 @@ fn setup_test_geometry(harness: &MinimalTestHarness) {
 // ============================================================================
 // Delete Key Tests
 // ============================================================================
-
-#[test]
-fn test_delete_selected_callback_tracks_calls() {
-    let harness = MinimalTestHarness::new();
-
-    assert_eq!(*harness.tracker.delete_selected.borrow(), 0);
-
-    // Simulate delete_selected being called
-    *harness.tracker.delete_selected.borrow_mut() += 1;
-
-    assert_eq!(*harness.tracker.delete_selected.borrow(), 1);
-}
+//
+// NodeEditor no longer binds Delete/Backspace/Ctrl+N itself — embedders own
+// the keymap. The tests below verify that key events still dispatch through
+// the harness without panicking, and that model-level delete operations work
+// independently of any key binding.
 
 #[test]
 fn test_delete_key_sends_event() {
     let harness = MinimalTestHarness::new();
     setup_test_geometry(&harness);
 
-    // The harness sets up on_delete_selected to increment the tracker
-    // When we send Delete key, if the FocusScope receives it, it calls delete_selected
-
-    // Note: In integration tests, we may need to ensure focus is set correctly
-    // For now, we test that the callback mechanism works via tracker
+    // NodeEditor no longer binds Delete itself; this just verifies the key
+    // event mechanism dispatches without panicking. The embedder is expected
+    // to bind Delete in its own parent FocusScope.
     harness.key_tap(Key::Delete);
-
-    // The actual behavior depends on Slint's focus handling
-    // This test verifies the key event mechanism works
 }
 
 #[test]
@@ -101,9 +89,9 @@ fn test_delete_removes_selected_nodes_from_model() {
     // Select node 2
     harness.selection.borrow_mut().handle_interaction(2, false);
 
-    // Simulate delete operation
-    // In real code, on_delete_selected would remove selected nodes
-    // Here we simulate that behavior directly
+    // Simulate delete operation directly on the model. Embedders are
+    // responsible for binding a key to invoke this work; the test exercises
+    // the model-level outcome independent of any keymap.
     let to_delete: Vec<i32> = harness.selection.borrow().iter().copied().collect();
     for id in to_delete {
         for i in 0..harness.nodes.row_count() {
@@ -360,22 +348,6 @@ fn test_text_input_dispatch() {
 
     // Test that text input can be dispatched (for potential search/rename features)
     harness.text_input("test");
-}
-
-// ============================================================================
-// Ctrl+N Add Node Tests
-// ============================================================================
-
-#[test]
-fn test_add_node_requested_callback_tracking() {
-    let harness = MinimalTestHarness::new();
-
-    assert_eq!(*harness.tracker.add_node_requested.borrow(), 0);
-
-    // Simulate Ctrl+N triggering add_node_requested
-    *harness.tracker.add_node_requested.borrow_mut() += 1;
-
-    assert_eq!(*harness.tracker.add_node_requested.borrow(), 1);
 }
 
 // ============================================================================

--- a/tests/ui/test.slint
+++ b/tests/ui/test.slint
@@ -96,9 +96,7 @@ export component MainWindow inherits Window {
     callback link-requested <=> editor.link-requested;
     callback link-cancelled <=> editor.link-cancelled;
     callback selection-changed <=> editor.selection-changed;
-    callback delete-selected <=> editor.delete-selected;
     callback context-menu-requested <=> editor.context-menu-requested;
-    callback add-node-requested <=> editor.add-node-requested;
 
     // Selection callbacks
     callback select-node <=> editor.select-node;


### PR DESCRIPTION
NodeEditor previously had an anonymous internal FocusScope as a sibling of `@children` and a hard-coded keymap (Delete/Backspace, Escape, Ctrl+N) that emitted callbacks the embedder was forced to consume. That arrangement had two problems:

1. The internal FocusScope was unreachable. Embedders could not call `.focus()` on NodeEditor or restore focus after a transient overlay, so users had to click the editor to activate keyboard shortcuts. Worse, because the FocusScope was a sibling of `@children` rather than an ancestor, keys rejected by a focused TextInput inside a node bubbled past NodeEditor entirely — Delete and friends did nothing while in-node inputs had focus.

2. The hard-coded keymap was both opinionated and unbypassable. Because NodeEditor was the closest ancestor FocusScope of any focused descendant, its `key-pressed` ran before any embedder-side parent FocusScope could see the event. Embedders could not remap Delete, Escape, or Ctrl+N — only suppress them after the fact.

This commit makes NodeEditor inherit FocusScope and removes its key handling entirely:

* `export component NodeEditor inherits FocusScope` — the component is now itself the focusable surface. Embedders call `editor.focus()` to focus it programmatically; `focus-on-click` (true by default on FocusScope) handles click activation.
* The internal anonymous FocusScope is gone. Because NodeEditor is now on the ancestor path of every child, rejected keys from any focused descendant (including in-node TextInputs) bubble through it and reach the embedder's parent FocusScope.
* The `key-pressed` handler is deleted. NodeEditor no longer dictates any keyboard bindings.
* The vestigial callbacks `delete-selected`, `add-node-requested`, and `navigate-up` are removed. They were only ever emitted from the deleted key handler — they had no other producers and no domain meaning of their own (`navigate-up` in particular leaks the multi-level-graph concept of one specific embedder into a component that knows nothing about it).
* `is-creating-link` and `cancel-link-creation()` were already publicly exposed; embedders use them to bind Escape (or any other key) to cancel an in-progress link drag.

Tests, the advanced example, and the README are updated to reflect the new contract. The advanced example demonstrates the recommended pattern: a parent FocusScope wraps the editor, binds keys to operations and embedder callbacks, and uses `init => editor.focus()` to set initial focus.

This is a breaking API change for direct consumers of the upstream crate; embedders must move their keymap into a parent FocusScope. Focus is structural; keymap is policy — this commit separates them.